### PR TITLE
fix: use relative assets for build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => ({
     host: "::",
     port: 8080,
   },
+  base: "./",
   plugins: [
     react(),
     mode === 'development' &&


### PR DESCRIPTION
## Summary
- use relative base path in Vite config

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c1a9bfb44833191a9a95739af4b57