### PR TITLE
Fix Support Section anchor buttons

### DIFF
--- a/src/components/sections/SupportSection.tsx
+++ b/src/components/sections/SupportSection.tsx
@@ -11,8 +11,12 @@ export default function SupportSection() {
         </p>
       </div>
       <div className="flex flex-wrap gap-3">
-        <a href="#donate"><Button size="lg">Donate</Button></a>
-        <a href="#volunteer"><Button size="lg" variant="secondary">Volunteer</Button></a>
+        <Button asChild size="lg">
+          <a href="#donate">Donate</a>
+        </Button>
+        <Button asChild size="lg" variant="secondary">
+          <a href="#volunteer">Volunteer</a>
+        </Button>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- use Button `asChild` property for Donate and Volunteer links

## Testing
- `npm run lint` *(fails: Unexpected any and other pre-existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ca640cc64833182138bedd11aa13c