### PR TITLE
Fix Support Section anchor buttons

### DIFF
--- a/src/components/sections/SupportSection.tsx
+++ b/src/components/sections/SupportSection.tsx
@@ -1,6 +1,14 @@
 import { Button } from "@/components/ui/button";
 
-export default function SupportSection() {
+interface SupportSectionProps {
+  onDonateClick: () => void;
+  onVolunteerClick: () => void;
+}
+
+export default function SupportSection({
+  onDonateClick,
+  onVolunteerClick,
+}: SupportSectionProps) {
   return (
     <section className="container py-12">
       <div className="mb-6">
@@ -11,8 +19,12 @@ export default function SupportSection() {
         </p>
       </div>
       <div className="flex flex-wrap gap-3">
-        <a href="#donate"><Button size="lg">Donate</Button></a>
-        <a href="#volunteer"><Button size="lg" variant="secondary">Volunteer</Button></a>
+        <Button size="lg" onClick={onDonateClick}>
+          Donate
+        </Button>
+        <Button size="lg" variant="secondary" onClick={onVolunteerClick}>
+          Volunteer
+        </Button>
       </div>
     </section>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -164,7 +164,7 @@ const Index = () => {
             <a href="#leaders" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Leaders</a>
           </nav>
           <div className="flex gap-2">
-            <Button variant="secondary" className="hidden sm:inline-flex" onClick={() => setJoinOpen(true)}><Users className="h-4 w-4 mr-2" />Join</Button>
+            <Button variant="secondary" onClick={() => setJoinOpen(true)}><Users className="h-4 w-4 mr-2" />Join</Button>
             <Button onClick={() => setDonateOpen(true)}><Heart className="h-4 w-4 mr-2" />Donate</Button>
           </div>
         </div>
@@ -248,8 +248,10 @@ const Index = () => {
           </div>
 
         </section>
-
-        <SupportSection />
+        <SupportSection
+          onDonateClick={() => setDonateOpen(true)}
+          onVolunteerClick={() => setJoinOpen(true)}
+        />
         <DocsSection />
 
         {/* Gallery */}


### PR DESCRIPTION
## Summary
- connect Support section Donate and Volunteer buttons to dialog handlers
- show Join button in the header on mobile

## Testing
- `npm run lint` *(fails: Unexpected any and other pre-existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ca640cc64833182138bedd11aa13c