### PR TITLE
Fix support buttons to open dialogs

### DIFF
--- a/src/components/sections/SupportSection.tsx
+++ b/src/components/sections/SupportSection.tsx
@@ -19,11 +19,11 @@ export default function SupportSection({
         </p>
       </div>
       <div className="flex flex-wrap gap-3">
-        <Button asChild size="lg">
-          <a href="#donate">Donate</a>
+        <Button size="lg" onClick={onDonateClick}>
+          Donate
         </Button>
-        <Button asChild size="lg" variant="secondary">
-          <a href="#volunteer">Volunteer</a>
+        <Button size="lg" variant="secondary" onClick={onVolunteerClick}>
+          Volunteer
         </Button>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- use click handlers for Donate and Volunteer buttons in Support section to open dialogs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 32 errors, 6 warnings)
- `npx eslint src/components/sections/SupportSection.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cac9baf788331b682ae7c467e4fef