### PR TITLE
feat: add preview image for social sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,13 +20,13 @@
     <meta property="og:title" content="Girard Music & Drama Boosters" />
     <meta property="og:description" content="Support Girard Music & Drama Boosters—events, performances, and ways to get involved." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="./lovable-uploads/4dd1825b-a51e-4884-9527-cb64042a826c.png" />
-    <meta property="og:image:alt" content="Girard Music & Drama Boosters logo" />
+    <meta property="og:image" content="./lovable-uploads/0edb8d5e-6f68-449c-bd0e-a64425869f8f.png" />
+    <meta property="og:image:alt" content="Girard Music & Drama Boosters promotional image" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Girard Music & Drama Boosters" />
     <meta name="twitter:description" content="Support Girard Music & Drama Boosters—events, performances, and ways to get involved." />
-    <meta name="twitter:image" content="./lovable-uploads/4dd1825b-a51e-4884-9527-cb64042a826c.png" />
+    <meta name="twitter:image" content="./lovable-uploads/0edb8d5e-6f68-449c-bd0e-a64425869f8f.png" />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- replace social preview image meta tags with a larger promotional image

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 32 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689d3080807883319a8bf8c749569002