### PR TITLE
Add interactive effects to leadership cards

### DIFF
--- a/src/components/sections/LeaderCard.tsx
+++ b/src/components/sections/LeaderCard.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface LeaderCardProps {
+  name: string;
+  role: string;
+}
+
+export default function LeaderCard({ name, role }: LeaderCardProps) {
+  const [flipped, setFlipped] = useState(false);
+
+  return (
+    <div
+      className="[perspective:1000px] cursor-pointer transition-transform duration-300 hover:-rotate-1 hover:scale-105"
+      onClick={() => setFlipped((f) => !f)}
+    >
+      <Card
+        className={cn(
+          "relative h-32 w-full p-5 [transform-style:preserve-3d] transition-transform duration-700",
+          flipped && "[transform:rotateY(180deg)]"
+        )}
+      >
+        <div className="absolute inset-0 flex flex-col [backface-visibility:hidden]">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">{role}</div>
+          <div className="text-lg font-semibold mt-1">{name}</div>
+        </div>
+        <div className="absolute inset-0 flex items-center justify-center bg-primary text-primary-foreground text-center [transform:rotateY(180deg)] [backface-visibility:hidden]">
+          <p className="text-sm">Thanks for supporting the boosters!</p>
+        </div>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import LeaderCard from "@/components/sections/LeaderCard";
 import { Calendar as CalendarIcon, Users, Heart } from "lucide-react";
 import EventCard from "@/components/events/EventCard";
 import { CategoryChip } from "@/components/events/CategoryChip";
@@ -279,10 +279,7 @@ const Index = () => {
               { name: "Cheyelle Couse", role: "Secretary" },
               { name: "Joe Meka", role: "Social Media" },
             ].map((p) => (
-              <Card key={p.name} className="p-5 animate-fade-in hover-scale">
-                <div className="text-xs uppercase tracking-wide text-muted-foreground">{p.role}</div>
-                <div className="text-lg font-semibold mt-1">{p.name}</div>
-              </Card>
+              <LeaderCard key={p.name} name={p.name} role={p.role} />
             ))}
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Introduce `LeaderCard` component that scales on hover and flips to reveal a message when clicked
- Use new `LeaderCard` for Leaders & Staff section on home page

## Testing
- `npm run lint` *(fails: Unexpected any and other existing errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d6a031a5883318f0c26ef8b59d627