### PR TITLE
Use absolute URLs for social preview metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Girard Music & Drama Boosters | Support the Arts</title>
     <meta name="description" content="Support Girard Music & Drama Boosters—events, performances, and ways to get involved." />
-    <link rel="canonical" href="/" />
+    <link rel="canonical" href="https://www.girardarts.org/" />
     <link rel="icon" href="./lovable-uploads/4dd1825b-a51e-4884-9527-cb64042a826c.png" type="image/png" />
 
     <!-- Fonts: Inter (UI) + Playfair Display (Headings) -->
@@ -24,18 +24,18 @@
 
     <meta name="author" content="Girard Music & Drama Boosters" />
     <meta name="robots" content="index, follow" />
-    <meta property="og:url" content="https://example.com/" />
+    <meta property="og:url" content="https://www.girardarts.org/" />
     <meta property="og:site_name" content="Girard Music & Drama Boosters" />
     <meta property="og:title" content="Girard Music & Drama Boosters" />
     <meta property="og:description" content="Support Girard Music & Drama Boosters—events, performances, and ways to get involved." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="./lovable-uploads/0edb8d5e-6f68-449c-bd0e-a64425869f8f.png" />
+    <meta property="og:image" content="https://www.girardarts.org/lovable-uploads/0edb8d5e-6f68-449c-bd0e-a64425869f8f.png" />
     <meta property="og:image:alt" content="Girard Music & Drama Boosters promotional image" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Girard Music & Drama Boosters" />
     <meta name="twitter:description" content="Support Girard Music & Drama Boosters—events, performances, and ways to get involved." />
-    <meta name="twitter:image" content="./lovable-uploads/0edb8d5e-6f68-449c-bd0e-a64425869f8f.png" />
+    <meta name="twitter:image" content="https://www.girardarts.org/lovable-uploads/0edb8d5e-6f68-449c-bd0e-a64425869f8f.png" />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- ensure Open Graph and Twitter images point to absolute URLs
- set canonical and og:url to `https://www.girardarts.org/`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ec778b5a08331abcdda0208e6b0ca