### PR TITLE
Fix event date parsing to avoid UTC offset

### DIFF
--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -3,13 +3,14 @@ import { Button } from "@/components/ui/button";
 import { Calendar as CalendarIcon, MapPin } from "lucide-react";
 import { downloadICSForEvent } from "@/lib/ics";
 import type { EventItem } from "@/types/events";
+import { normalizeEventDate } from "@/lib/utils";
 
 interface Props {
   event: EventItem;
 }
 
 export default function EventCard({ event }: Props) {
-  const date = new Date(event.date);
+  const date = normalizeEventDate(event.date);
   const dateStr = date.toLocaleDateString(undefined, {
     weekday: "short",
     month: "short",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,18 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Parse an event date string in MM-DD-YYYY or YYYY-MM-DD format and
+// construct a Date object in the local timezone without any UTC shift.
+export function normalizeEventDate(dateStr: string): Date {
+  const parts = dateStr.split("-");
+  let month: number, day: number, year: number;
+  if (parts[0].length === 4) {
+    // YYYY-MM-DD
+    [year, month, day] = parts.map(Number);
+  } else {
+    // MM-DD-YYYY
+    [month, day, year] = parts.map(Number);
+  }
+  return new Date(year, month - 1, day);
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
+import { normalizeEventDate } from "@/lib/utils";
 
 
 const Index = () => {
@@ -40,9 +41,9 @@ const Index = () => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const eventAnnouncements = events
-      .filter((e) => new Date(e.date) >= today)
+      .filter((e) => normalizeEventDate(e.date) >= today)
       .map((e) => {
-        const date = new Date(e.date);
+        const date = normalizeEventDate(e.date);
         const dateStr = date.toLocaleDateString(undefined, {
           weekday: "short",
           month: "short",
@@ -124,7 +125,7 @@ const Index = () => {
 
   const monthEvents = useMemo(() => {
     return filtered.filter((e) => {
-      const d = new Date(e.date);
+      const d = normalizeEventDate(e.date);
       return (
         d.getFullYear() === calendarMonth.getFullYear() &&
         d.getMonth() === calendarMonth.getMonth()
@@ -258,7 +259,7 @@ const Index = () => {
             <Calendar
               month={calendarMonth}
               onMonthChange={setCalendarMonth}
-              modifiers={{ event: filtered.map((e) => new Date(e.date)) }}
+              modifiers={{ event: filtered.map((e) => normalizeEventDate(e.date)) }}
               modifiersClassNames={{ event: "bg-accent text-accent-foreground" }}
               className="rounded-md border border-border"
             />


### PR DESCRIPTION
## Summary
- add `normalizeEventDate` helper to parse MM-DD-YYYY/ISO dates in local time
- use normalized dates in announcements, calendar view, and event cards to prevent off-by-one rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f87b908f883319e41c68b30b07381