### PR TITLE
Add interactive announcement slider

### DIFF
--- a/src/components/sections/AnnouncementsBar.tsx
+++ b/src/components/sections/AnnouncementsBar.tsx
@@ -1,3 +1,6 @@
+import { useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
 interface Announcement { id: string; text: string }
 
 interface Props {
@@ -5,17 +8,44 @@ interface Props {
 }
 
 export default function AnnouncementsBar({ items }: Props) {
+  const [index, setIndex] = useState(0);
   if (!items?.length) return null;
+
+  const prev = () => setIndex((i) => (i - 1 + items.length) % items.length);
+  const next = () => setIndex((i) => (i + 1) % items.length);
+
   return (
     <aside className="w-full border-y border-border bg-accent/30">
-      <div className="container py-2 text-sm">
-        <ul className="flex flex-wrap gap-4">
-          {items.map((a) => (
-            <li key={a.id} className="before:content-['•'] before:mr-2 before:text-muted-foreground">
-              {a.text}
-            </li>
-          ))}
-        </ul>
+      <div className="container py-2 text-sm flex items-center gap-2">
+        <button
+          aria-label="Previous announcement"
+          onClick={prev}
+          className="p-1 rounded-full hover:bg-accent transition-all active:scale-95"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <div className="overflow-hidden flex-1">
+          <ul
+            className="flex transition-transform duration-500 ease-in-out"
+            style={{ transform: `translateX(-${index * 100}%)` }}
+          >
+            {items.map((a) => (
+              <li
+                key={a.id}
+                className="w-full shrink-0 text-center whitespace-nowrap"
+              >
+                {a.text}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <button
+          aria-label="Next announcement"
+          onClick={next}
+          className="p-1 rounded-full hover:bg-accent transition-all active:scale-95"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- Add arrow-controlled slider for announcements to keep banner to one line with smooth animations

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: see logged ESLint errors)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f8a59649883319f842f218203f05f