### PR TITLE
Add video upload admin and homepage showcase

### DIFF
--- a/src/components/sections/VideoShowcase.tsx
+++ b/src/components/sections/VideoShowcase.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+interface VideoItem {
+  src: string;
+  title: string;
+}
+
+export default function VideoShowcase({ videos }: { videos: VideoItem[] }) {
+  if (videos.length === 0) return null;
+  const video = videos[0];
+  return (
+    <section id="videos" className="py-12 bg-background text-foreground">
+      <div className="container">
+        <div className="mb-6 text-center">
+          <h2 className="font-display text-2xl sm:text-3xl font-semibold">Band Videos</h2>
+          <p className="text-muted-foreground">Watch our musicians in action.</p>
+        </div>
+        <div className="max-w-4xl mx-auto relative bg-black rounded-lg overflow-hidden shadow-2xl">
+          <div className="absolute inset-y-0 left-0 w-4 bg-primary" aria-hidden="true" />
+          <div className="absolute inset-y-0 right-0 w-4 bg-primary" aria-hidden="true" />
+          <video src={video.src} controls className="w-full h-full" title={video.title} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -127,6 +127,36 @@ export type Database = {
           updated_at?: string
         }
         Relationships: []
+      },
+      videos: {
+        Row: {
+          created_at: string
+          id: string
+          order_index: number
+          path: string
+          published: boolean
+          title: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          order_index?: number
+          path: string
+          published?: boolean
+          title?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          order_index?: number
+          path?: string
+          published?: boolean
+          title?: string | null
+          updated_at?: string
+        }
+        Relationships: []
       }
     }
     Views: {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,6 +11,7 @@ import SupportSection from "@/components/sections/SupportSection";
 import DocsSection from "@/components/sections/DocsSection";
 import ContactSection from "@/components/sections/ContactSection";
 import SocialHighlight from "@/components/sections/SocialHighlight";
+import VideoShowcase from "@/components/sections/VideoShowcase";
 import { Calendar } from "@/components/ui/calendar";
 import type { CalendarType, EventItem } from "@/types/events";
 import { Link } from "react-router-dom";
@@ -29,6 +30,7 @@ const Index = () => {
   const [selected, setSelected] = useState<CalendarType[]>(["Band", "Drama", "Fundraising", "General"]);
   const [query, setQuery] = useState("");
   const [galleryImages, setGalleryImages] = useState<{ src: string; alt: string }[]>([]);
+  const [videos, setVideos] = useState<{ src: string; title: string }[]>([]);
   const [events, setEvents] = useState<EventItem[]>([]);
   const [joinOpen, setJoinOpen] = useState(false);
   const [donateOpen, setDonateOpen] = useState(false);
@@ -118,6 +120,25 @@ const Index = () => {
     })();
   }, []);
 
+  // Load videos from Supabase storage via videos table
+  useEffect(() => {
+    (async () => {
+      const { data, error } = await (supabase as any)
+        .from("videos")
+        .select("path,title,order_index,published,created_at")
+        .eq("published", true)
+        .order("order_index", { ascending: true })
+        .order("created_at", { ascending: true });
+      if (!error && data) {
+        const mapped = (data as any[]).map((v) => {
+          const { data: pub } = (supabase as any).storage.from("videos").getPublicUrl(v.path);
+          return { src: pub.publicUrl as string, title: v.title || "Band video" };
+        });
+        setVideos(mapped);
+      }
+    })();
+  }, []);
+
   const filtered = useMemo(() => {
     return events.filter((e) =>
       selected.includes(e.calendar) && e.title.toLowerCase().includes(query.toLowerCase())
@@ -178,6 +199,7 @@ const Index = () => {
           </a>
           <nav className="hidden md:flex gap-4">
             <a href="#events" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Events</a>
+            <a href="#videos" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Videos</a>
             <a href="#gallery" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Gallery</a>
             <a href="#leaders" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Leaders</a>
           </nav>
@@ -290,6 +312,8 @@ const Index = () => {
           onVolunteerClick={() => setJoinOpen(true)}
         />
         <DocsSection />
+
+        <VideoShowcase videos={videos} />
 
         {/* Gallery */}
         <section id="gallery" className="container py-12">

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import DocumentsManager from "./DocumentsManager";
 import EventsManager from "./EventsManager";
 import PhotosManager from "./PhotosManager";
+import VideosManager from "./VideosManager";
 const STATIC_WHITELIST = new Set([
   "girardmusicboosters@gmail.com",
   "jordanlander@gmail.com",
@@ -112,10 +113,10 @@ create policy "Manage admin_emails" on public.admin_emails
             <div className="grid gap-6">
               <Card>
                 <CardContent className="p-6">
-                <h2 className="font-semibold">Events</h2>
-                <div className="mt-3">
-                  <EventsManager />
-                </div>
+                  <h2 className="font-semibold">Events</h2>
+                  <div className="mt-3">
+                    <EventsManager />
+                  </div>
                 </CardContent>
               </Card>
               <Card>
@@ -123,6 +124,14 @@ create policy "Manage admin_emails" on public.admin_emails
                   <h2 className="font-semibold">Photos</h2>
                   <div className="mt-3">
                     <PhotosManager />
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-6">
+                  <h2 className="font-semibold">Videos</h2>
+                  <div className="mt-3">
+                    <VideosManager />
                   </div>
                 </CardContent>
               </Card>

--- a/src/pages/admin/VideosManager.tsx
+++ b/src/pages/admin/VideosManager.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { toast } from "sonner";
+
+export type VideoRow = {
+  id: string;
+  path: string;
+  title: string | null;
+  order_index: number;
+  published: boolean;
+};
+
+export default function VideosManager() {
+  const [items, setItems] = useState<VideoRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [title, setTitle] = useState("");
+  const [orderIndex, setOrderIndex] = useState(0);
+  const [savingId, setSavingId] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    const { data, error } = await (supabase as any)
+      .from("videos")
+      .select("id,path,title,order_index,published")
+      .order("order_index", { ascending: true })
+      .order("created_at", { ascending: true });
+    if (error) {
+      toast.error("Failed to load videos", { description: error.message });
+    } else {
+      setItems((data as VideoRow[]) ?? []);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const upload = async () => {
+    if (!file) return toast.error("Choose a file first");
+    setUploading(true);
+    const ext = file.name.split(".").pop()?.toLowerCase() || "mp4";
+    const path = `${Date.now()}_${Math.random().toString(36).slice(2)}.${ext}`;
+
+    const { error: uploadErr } = await (supabase as any)
+      .storage
+      .from("videos")
+      .upload(path, file, { upsert: false, contentType: file.type || undefined });
+
+    if (uploadErr) {
+      setUploading(false);
+      return toast.error("Upload failed", { description: uploadErr.message });
+    }
+
+    const { error: insertErr } = await (supabase as any)
+      .from("videos")
+      .insert({ path, title, order_index: orderIndex, published: true });
+
+    setUploading(false);
+    if (insertErr) {
+      toast.error("Failed to save video record", { description: insertErr.message });
+    } else {
+      toast.success("Video uploaded");
+      setFile(null);
+      setTitle("");
+      setOrderIndex(0);
+      (document.getElementById("video-file") as HTMLInputElement | null)?.value && ((document.getElementById("video-file") as HTMLInputElement).value = "");
+      load();
+    }
+  };
+
+  const publicUrl = (path: string) => {
+    const { data } = (supabase as any).storage.from("videos").getPublicUrl(path);
+    return data.publicUrl as string;
+  };
+
+  const save = async (row: VideoRow) => {
+    setSavingId(row.id);
+    const { error } = await (supabase as any)
+      .from("videos")
+      .update({ title: row.title, order_index: row.order_index, published: row.published })
+      .eq("id", row.id);
+    setSavingId(null);
+    if (error) {
+      toast.error("Save failed", { description: error.message });
+    } else {
+      toast.success("Saved");
+      load();
+    }
+  };
+
+  const remove = async (row: VideoRow) => {
+    if (!confirm("Delete this video? This removes it from storage too.")) return;
+    const { error: delRowErr } = await (supabase as any).from("videos").delete().eq("id", row.id);
+    if (delRowErr) return toast.error("Delete failed", { description: delRowErr.message });
+    await (supabase as any).storage.from("videos").remove([row.path]);
+    toast.success("Deleted");
+    setItems((prev) => prev.filter((i) => i.id !== row.id));
+  };
+
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-4">
+        <div>
+          <h3 className="font-semibold">Manage Videos</h3>
+          <p className="text-sm text-muted-foreground">Upload, title, publish, and order band videos.</p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5 items-end">
+          <input id="video-file" type="file" accept="video/*" onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+          <Input placeholder="Title" value={title} onChange={(e) => setTitle(e.target.value)} />
+          <Input type="number" placeholder="Order" value={orderIndex} onChange={(e) => setOrderIndex(Number(e.target.value))} />
+          <div className="lg:col-span-2 flex justify-end">
+            <Button onClick={upload} disabled={uploading}>{uploading ? "Uploading…" : "Upload"}</Button>
+          </div>
+        </div>
+
+        <div className="border-t border-border pt-4" />
+
+        {loading ? (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        ) : items.length === 0 ? (
+          <div className="text-sm text-muted-foreground">No videos yet.</div>
+        ) : (
+          <div className="space-y-3">
+            {items.map((row) => (
+              <div key={row.id} className="grid gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 items-center">
+                <div className="flex items-center gap-3">
+                  <video src={publicUrl(row.path)} className="w-16 h-16 object-cover rounded-md border border-border" />
+                  <span className="text-xs text-muted-foreground break-all">{row.path}</span>
+                </div>
+                <Input
+                  value={row.title ?? ""}
+                  onChange={(e) =>
+                    setItems((prev) => prev.map((it) => (it.id === row.id ? { ...it, title: e.target.value } : it)))
+                  }
+                  placeholder="Title"
+                />
+                <Input
+                  type="number"
+                  value={row.order_index}
+                  onChange={(e) =>
+                    setItems((prev) => prev.map((it) => (it.id === row.id ? { ...it, order_index: Number(e.target.value) } : it)))
+                  }
+                />
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={row.published}
+                    onCheckedChange={(v) =>
+                      setItems((prev) => prev.map((it) => (it.id === row.id ? { ...it, published: v } : it)))
+                    }
+                    aria-label={`Toggle publish`}
+                  />
+                  <span className="text-sm">Published</span>
+                </div>
+                <div className="flex items-center gap-2 justify-end lg:col-span-1">
+                  <Button variant="outline" onClick={() => save(row)} disabled={savingId === row.id}>
+                    {savingId === row.id ? "Saving…" : "Save"}
+                  </Button>
+                  <Button variant="destructive" onClick={() => remove(row)}>Delete</Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/supabase/migrations/20250813040600-add-videos.sql
+++ b/supabase/migrations/20250813040600-add-videos.sql
@@ -1,0 +1,60 @@
+-- Create videos table and policies
+create table if not exists public.videos (
+  id uuid primary key default gen_random_uuid(),
+  path text not null,
+  title text,
+  order_index int not null default 0,
+  published boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.videos enable row level security;
+
+drop trigger if exists trg_videos_updated_at on public.videos;
+create trigger trg_videos_updated_at
+before update on public.videos
+for each row execute function public.set_updated_at();
+
+-- Policies for videos
+ drop policy if exists "Public can view published videos" on public.videos;
+create policy "Public can view published videos" on public.videos
+for select to anon
+using (published = true);
+
+ drop policy if exists "Authenticated can view all videos" on public.videos;
+create policy "Authenticated can view all videos" on public.videos
+for select to authenticated
+using (true);
+
+ drop policy if exists "Admins manage videos" on public.videos;
+create policy "Admins manage videos" on public.videos
+for all to authenticated
+using (public.is_admin())
+with check (public.is_admin());
+
+-- Ensure storage bucket and policies for videos
+insert into storage.buckets (id, name, public)
+values ('videos', 'videos', true)
+on conflict (id) do nothing;
+
+drop policy if exists "Public read videos" on storage.objects;
+create policy "Public read videos" on storage.objects
+for select to anon
+using (bucket_id = 'videos');
+
+drop policy if exists "Admins insert videos" on storage.objects;
+create policy "Admins insert videos" on storage.objects
+for insert to authenticated
+with check (bucket_id = 'videos' and public.is_admin());
+
+drop policy if exists "Admins update videos" on storage.objects;
+create policy "Admins update videos" on storage.objects
+for update to authenticated
+using (bucket_id = 'videos' and public.is_admin())
+with check (bucket_id = 'videos' and public.is_admin());
+
+drop policy if exists "Admins delete videos" on storage.objects;
+create policy "Admins delete videos" on storage.objects
+for delete to authenticated
+using (bucket_id = 'videos' and public.is_admin());


### PR DESCRIPTION
## Summary
- add Supabase videos table and bucket migration
- extend admin dashboard with video upload/management
- show latest band video on homepage with movie-theater styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2ace49a8833196b008be2c18fa54