### PR TITLE
Promote Oliver! musical weekend

### DIFF
--- a/public/lovable-uploads/oliver-musical.svg
+++ b/public/lovable-uploads/oliver-musical.svg
@@ -1,0 +1,41 @@
+<svg width="720" height="1080" viewBox="0 0 720 1080" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Oliver! Musical Poster</title>
+  <desc id="desc">Stylized poster for Girard Dramatics production of Oliver with show dates and ticket information.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="70%" stop-color="#111"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </linearGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="720" height="1080" fill="url(#bg)"/>
+  <g transform="translate(90,140)">
+    <text x="0" y="20" fill="#f5f5f5" font-family="'DM Sans', 'Inter', system-ui, sans-serif" font-weight="700" font-size="34">Girard Dramatics</text>
+    <text x="0" y="74" fill="#d6d6d6" font-family="'DM Sans', 'Inter', system-ui, sans-serif" font-weight="400" font-size="24">presents</text>
+    <text x="0" y="126" fill="#f5f5f5" font-family="'DM Sans', 'Inter', system-ui, sans-serif" font-weight="700" font-size="28">Rice Avenue Middle School’s Production</text>
+  </g>
+  <g transform="translate(90,240)">
+    <path d="M220 40c100 -55 230 -54 270 -22c-45 0 -120 22 -185 48c90 -18 170 -5 190 18c-44 5 -118 28 -210 56c70 -2 120 8 138 20c-32 14 -92 30 -170 48c-74 22 -122 54 -140 82c-14 -30 16 -70 78 -110c-68 16 -118 20 -150 12c18 -20 70 -46 146 -68c-70 2 -122 -12 -146 -32c34 -18 92 -30 179 -52z" fill="#d6001c" filter="url(#glow)" opacity="0.9"/>
+    <path d="M328 -6c62 -20 126 -24 160 4c-36 -8 -88 -4 -138 12c34 -4 66 0 84 12c-26 2 -60 10 -100 22c-40 14 -64 32 -76 50c-10 -18 6 -40 38 -60c-34 8 -60 10 -78 6c12 -12 42 -26 88 -40z" fill="#f22f2f" opacity="0.9"/>
+    <text x="24" y="220" fill="#f7d733" font-family="'Snell Roundhand', 'Brush Script MT', cursive" font-size="140" font-weight="700">Oliver!</text>
+    <text x="320" y="250" fill="#f7d733" font-family="'Snell Roundhand', 'Brush Script MT', cursive" font-size="40" font-weight="600">the musical</text>
+  </g>
+  <g transform="translate(90,560)" fill="#f5f5f5" font-family="'DM Sans', 'Inter', system-ui, sans-serif">
+    <text x="0" y="0" font-size="30" font-weight="700">Friday, November 21, 2025 at 7 p.m.</text>
+    <text x="0" y="52" font-size="30" font-weight="700">Saturday, November 22, 2025 at 7 p.m.</text>
+    <text x="0" y="104" font-size="30" font-weight="700">Sunday, November 23, 2025 at 2 p.m.</text>
+    <text x="0" y="168" font-size="26" font-weight="700">Students: $3   Senior Citizens: $4   Adults: $5</text>
+    <text x="0" y="210" font-size="24" fill="#d6d6d6">Tickets are available at the door one hour before each performance.</text>
+  </g>
+  <g transform="translate(90,860)">
+    <text x="0" y="0" fill="#f5f5f5" font-family="'DM Sans', 'Inter', system-ui, sans-serif" font-size="30" font-weight="700">Girard High School Auditorium</text>
+    <text x="0" y="46" fill="#d6d6d6" font-family="'DM Sans', 'Inter', system-ui, sans-serif" font-size="24">By special arrangement with Cameron Mackintosh &amp; Lionel Bart’s OLIVER!</text>
+  </g>
+</svg>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -55,7 +55,11 @@ const Index = () => {
         return { id: e.id, text: `${dateStr}: ${e.title}` };
       });
     return [
-      { id: "season", text: "Welcome to the 2025 season: Shuffle!" },
+      {
+        id: "season",
+        text:
+          "This weekend: Oliver! at Girard High School Auditorium — Fri & Sat 7 p.m., Sun 2 p.m.",
+      },
       ...eventAnnouncements,
     ];
   }, [events]);
@@ -241,10 +245,13 @@ const Index = () => {
           </div>
           <div className="grid gap-6">
             <FeatureCard
-              title="2025 Show: Shuffle"
-              description="Catch the Yellowjacket Marching Band’s 2025 show — a high‑energy mix of hits."
-              image={{ src: `${baseUrl}lovable-uploads/247cf6cb-e08a-4553-8660-470cb8641893.png`, alt: "Shuffle 2025 show artwork" }}
-              cta={{ label: "See Schedule", href: "#events" }}
+              title="Oliver! premieres this weekend"
+              description="Join Girard Dramatics for Rice Avenue Middle School’s production — Friday & Saturday at 7 p.m., Sunday at 2 p.m. Tickets: Students $3, Seniors $4, Adults $5."
+              image={{
+                src: `${baseUrl}lovable-uploads/oliver-musical.svg`,
+                alt: "Oliver! musical poster with show dates and ticket details",
+              }}
+              cta={{ label: "Get show details", href: "#events" }}
             />
             <FeatureCard
               title="The Sound of the Swarm"


### PR DESCRIPTION
## Summary
- update homepage announcement and featured content to highlight this weekend's Oliver! musical performances with schedule and ticket details
- add a new Oliver! poster asset for the production

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbc1c61e48331b864f5d8df0a6ab4)